### PR TITLE
remove --prefer-sources from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - composer self-update
 
 install:
-  - composer install --prefer-source
+  - composer install
 
 script:
   - ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml


### PR DESCRIPTION
After addressing issue #2 we travis can simply call composer without the `--prefer-sources` flag.
This should speed builds up.
